### PR TITLE
Use separate script for validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,4 +122,5 @@ deploy/*.py
 
 # validation logs
 logs/*.log
+scripts/*.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ install:
   - pip install pytest pep8 pyflakes
 script:
   - invoke runtests
+  - ./scripts/validate_spiders.sh

--- a/scripts/validate_spiders.sh
+++ b/scripts/validate_spiders.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Remove existing output
+rm scripts/*.json
+
+# Run scrapers that have changed
+git diff --name-only --diff-filter=AM HEAD...$TRAVIS_BRANCH | \
+    grep .*documenters_aggregator/spiders/.*\.py | \
+    xargs -I{} sh -c 'scraper=$(basename "${1%%.*}") ; scrapy crawl $scraper -o ./scripts/$scraper.json --loglevel=ERROR' -- {}
+
+# Validate any changed scrapers
+ls scripts/*.json | xargs -I{} sh -c 'invoke validate-spider $(basename "${1%%.*}")' -- {}

--- a/tasks.py
+++ b/tasks.py
@@ -13,6 +13,7 @@ TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templat
 SPIDERS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'documenters_aggregator/spiders')
 TESTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tests')
 FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tests/files')
+SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'scripts')
 
 # pty is not available on Windows
 try:
@@ -158,32 +159,13 @@ def _get_domains(start_urls):
 
 
 @task
-def validate_new_spiders(ctx):
-    """
-    Validates new spiders on Travis CI.
-
-    Gets the added or modified spiders between a
-    pull request branch's HEAD and the branch 
-    being merged into. Runs the new spiders and
-    saves the scraped items. Validates the
-    newly scraped items.
-    """
-    new_files = run(('git diff --name-only --diff-filter=AM HEAD...$TRAVIS_BRANCH'
-                     '| grep .*documenters_aggregator/spiders/.*\.py')).stdout
-    # new_files = run(('git diff --name-only HEAD...test_branch'
-    #                 '| grep .*documenters_aggregator/spiders/.*\.py')).stdout
-    spider_names = [x.split('/')[-1][:-3] for x in new_files.split('\n') if x]
-    for spider in spider_names:
-        run('scrapy crawl {0} -o {0}.json --loglevel=ERROR'.format(spider))
-        _validate_spider(spider)
-
-def _validate_spider(spider):
+def validate_spider(ctx, spider):
     """
     Validates scraped items from a spider.
     Passes if >=90% of the scraped items
     conform to the schema.
     """
-    scraped_items = json.load(open('{0}.json'.format(spider)))
+    scraped_items = json.load(open(os.path.join(SCRIPTS_DIR, '{0}.json'.format(spider))))
     validated_items = [{k: v for k, v in item.items() if k.startswith('val_')} for item in scraped_items]
     validation_summary = pd.DataFrame(validated_items).mean()
 
@@ -205,5 +187,5 @@ def _validate_spider(spider):
 ns = Collection()
 ns.add_task(genspider)
 ns.add_task(runtests)
-ns.add_task(validate_new_spiders)
+ns.add_task(validate_spider)
 ns.add_collection(ecs, 'ecs')


### PR DESCRIPTION
I thought it would be easier to work through some changes here than on the main repo. It felt easier to me to split out running the changed scrapers into a separate bash script, and this setup works when I pipe a list of filenames from a text file as a test.

The validation pipeline itself isn't working for me (adding `val_` to the JSON files), but I'm not sure if that's just because I didn't run it correctly. Also, do you think we could calculate the mean without pandas? It just seems like a large dependency to add for one function.

This setup looks really good overall, let me know what you think about some of those changes!